### PR TITLE
Remove Duncan Kennedy poissonconsulting.ca email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7388-1222")),
-    person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "aut",
+    person("Duncan", "Kennedy", , role = "aut",
            comment = c(ORCID = "0009-0001-4880-5751")),
     person("Poisson Consulting", role = "cph")
   )


### PR DESCRIPTION
Removes `duncan@poissonconsulting.ca` (no longer an active address) from DESCRIPTION; retains Duncan Kennedy as an author.