### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^CODE_OF_CONDUCT\.md$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/aws.R
+++ b/R/aws.R
@@ -41,21 +41,23 @@
 #' )
 #' }
 #' @export
-sbfx_save_aws_files <- function(bucket_name,
-                                sub = subfoldr2::sbf_get_sub(),
-                                main = subfoldr2::sbf_get_main(),
-                                data_type = NULL,
-                                year = NULL,
-                                month = NULL,
-                                day = NULL,
-                                file_name = NULL,
-                                file_extension = NULL,
-                                max_request_size = 1000,
-                                ask = getOption("sbf.ask", TRUE),
-                                silent = TRUE,
-                                aws_access_key_id = Sys.getenv("AWS_ACCESS_KEY_ID"),
-                                aws_secret_access_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
-                                region = Sys.getenv("AWS_REGION", "ca-central-1")) {
+sbfx_save_aws_files <- function(
+  bucket_name,
+  sub = subfoldr2::sbf_get_sub(),
+  main = subfoldr2::sbf_get_main(),
+  data_type = NULL,
+  year = NULL,
+  month = NULL,
+  day = NULL,
+  file_name = NULL,
+  file_extension = NULL,
+  max_request_size = 1000,
+  ask = getOption("sbf.ask", TRUE),
+  silent = TRUE,
+  aws_access_key_id = Sys.getenv("AWS_ACCESS_KEY_ID"),
+  aws_secret_access_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
+  region = Sys.getenv("AWS_REGION", "ca-central-1")
+) {
   rlang::check_installed("readwriteaws")
 
   file_list <- readwriteaws::rwa_list_su_files(

--- a/R/helper-pg.R
+++ b/R/helper-pg.R
@@ -1,7 +1,9 @@
-create_local_database <- function(schema = NULL,
-                                  table = NULL,
-                                  data = TRUE,
-                                  env = parent.frame()) {
+create_local_database <- function(
+  schema = NULL,
+  table = NULL,
+  data = TRUE,
+  env = parent.frame()
+) {
   # create a local database, schema and table (with or without data)
   # all objects that are created are removed (complete clean up)
   chk::chk_null_or(schema, vld = chk::vld_string)
@@ -68,7 +70,11 @@ create_local_database <- function(schema = NULL,
     withr::defer(
       {
         sql_drop <- paste0(
-          "DROP TABLE ", schema, ".", deparse(substitute(table)), ";"
+          "DROP TABLE ",
+          schema,
+          ".",
+          deparse(substitute(table)),
+          ";"
         )
         result4 <- DBI::dbSendQuery(conn_local, sql_drop)
         DBI::dbClearResult(result4)
@@ -152,9 +158,11 @@ check_db_table <- function(config_path, schema, tbl_name) {
   query
 }
 
-clean_up_schema <- function(config_path,
-                            schema = "boat_count",
-                            env = parent.frame()) {
+clean_up_schema <- function(
+  config_path,
+  schema = "boat_count",
+  env = parent.frame()
+) {
   withr::defer(DBI::dbDisconnect(conn))
   conn <- local_connection(config_path)
   cmd <- paste0("DROP SCHEMA ", schema)

--- a/R/postgres.R
+++ b/R/postgres.R
@@ -20,8 +20,10 @@
 #' sbfx_open_pg(config_path = "config.yml", config_value = "database")
 #' sbfx_close_pg(conn)
 #' }
-sbfx_open_pg <- function(config_path = getOption("psql.config_path", NULL),
-                         config_value = getOption("psql.config_value", "default")) {
+sbfx_open_pg <- function(
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   conn <- psql::psql_connect(
     config_path = config_path,
     config_value = config_value
@@ -69,11 +71,13 @@ sbfx_close_pg <- function(conn) {
 #' sbfx_backup_pg()
 #' sbfx_backup_pg("database-22")
 #' }
-sbfx_backup_pg <- function(db_dump_name = subfoldr2::sbf_get_db_name(),
-                           sub = subfoldr2::sbf_get_sub(),
-                           main = subfoldr2::sbf_get_main(),
-                           config_path = getOption("psql.config_path", NULL),
-                           config_value = getOption("psql.config_value", "default")) {
+sbfx_backup_pg <- function(
+  db_dump_name = subfoldr2::sbf_get_db_name(),
+  sub = subfoldr2::sbf_get_sub(),
+  main = subfoldr2::sbf_get_main(),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   path <- file_name(main, "dbs", sub, db_dump_name, ext = "sql")
   psql::psql_backup(
     path = path,
@@ -98,9 +102,11 @@ sbfx_backup_pg <- function(db_dump_name = subfoldr2::sbf_get_db_name(),
 #' sbfx_create_pg("new_database")
 #' sbfx_create_pg("new_database", config_path = "keys/config.yml")
 #' }
-sbfx_create_pg <- function(dbname,
-                           config_path = getOption("psql.config_path", NULL),
-                           config_value = getOption("psql.config_value", "default")) {
+sbfx_create_pg <- function(
+  dbname,
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   psql::psql_create_db(
     dbname = dbname,
     config_path = config_path,
@@ -129,9 +135,11 @@ sbfx_create_pg <- function(dbname,
 #'   comment TEXT)"
 #' )
 #' }
-sbfx_execute_pg <- function(sql,
-                            config_path = getOption("psql.config_path", NULL),
-                            config_value = getOption("psql.config_value", "default")) {
+sbfx_execute_pg <- function(
+  sql,
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   psql::psql_execute_db(
     sql = sql,
     config_path = config_path,
@@ -155,9 +163,11 @@ sbfx_execute_pg <- function(sql,
 #' sbfx_list_tables_pg()
 #' sbfx_list_tables_pg("boat_count")
 #' }
-sbfx_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
-                                config_path = getOption("psql.config_path", NULL),
-                                config_value = getOption("psql.config_value", "default")) {
+sbfx_list_tables_pg <- function(
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   psql::psql_list_tables(
     schema = schema,
     config_path = config_path,
@@ -183,10 +193,12 @@ sbfx_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
 #' sbfx_load_data_from_pg("capture")
 #' sbfx_load_data_from_pg("counts", "boat_count")
 #' }
-sbfx_load_data_from_pg <- function(x,
-                                   schema = getOption("psql.schema", "public"),
-                                   config_path = getOption("psql.config_path", NULL),
-                                   config_value = getOption("psql.config_value", "default")) {
+sbfx_load_data_from_pg <- function(
+  x,
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   psql::psql_read_table(
     tbl_name = x,
     schema = schema,
@@ -213,11 +225,13 @@ sbfx_load_data_from_pg <- function(x,
 #' sbfx_load_datas_from_pg(schema = "capture")
 #' sbfx_load_datas_from_pg(rename = toupper)
 #' }
-sbfx_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
-                                    rename = identity,
-                                    env = parent.frame(),
-                                    config_path = getOption("psql.config_path", NULL),
-                                    config_value = getOption("psql.config_value", "default")) {
+sbfx_load_datas_from_pg <- function(
+  schema = getOption("psql.schema", "public"),
+  rename = identity,
+  env = parent.frame(),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   chk::chk_s3_class(env, "environment")
   chk::chk_function(rename)
 
@@ -259,12 +273,16 @@ sbfx_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
 #' sbfx_save_data_to_pg(outing, "creel")
 #' sbfx_save_data_to_pg(outing_new, "creel", "outing")
 #' }
-sbfx_save_data_to_pg <- function(x,
-                                 x_name = NULL,
-                                 schema = getOption("psql.schema", "public"),
-                                 config_path = getOption("psql.config_path", NULL),
-                                 config_value = getOption("psql.config_value", "default")) {
-  if (is.null(x_name)) x_name <- deparse(substitute(x))
+sbfx_save_data_to_pg <- function(
+  x,
+  x_name = NULL,
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
+  if (is.null(x_name)) {
+    x_name <- deparse(substitute(x))
+  }
   psql::psql_add_data(
     tbl = x,
     schema = schema,

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -1,8 +1,6 @@
 roxygen2md::roxygen2md()
-styler::style_pkg(
-  scope = "line_breaks",
-  filetype = c("R", "Rmd")
-)
+system2("air", c("format", "."))
+styler::style_pkg(filetype = c("Rmd")) # Air currently doesn't format .Rmd files
 lintr::lint_package()
 
 devtools::test()


### PR DESCRIPTION
Closes #8

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)